### PR TITLE
chore(post-ouija): add post-ouija class to any article tag

### DIFF
--- a/app/components/conversation.jsx
+++ b/app/components/conversation.jsx
@@ -99,7 +99,7 @@ Conversation.componentWillMount = function() {
 
 Conversation.render = function() {
   var cx = React.addons.classSet;
-    var classes = cx({
+  var classes = cx({
     'ouija': true,
     'ouija-active': this.state.isActive
   });

--- a/app/index.js
+++ b/app/index.js
@@ -9,12 +9,20 @@
  * We abstract retrieving the configuration options and instantiate Ouija here
  **/
 
+var _ = require('lodash');
 var Ouija = require('./ouija');
+
+var DEFAULTS = {
+  articleContent: '.post-content'
+};
 
 var config = {
   identifier: window.ouija_identifier,  // Ghost Post UID
-  connect_url: window.ouija_connect_url // GoInstant connect URL
+  connectUrl: window.ouija_connect_url, // GoInstant connect URL
+  articleContent: window.ouija_article_content // Selector for article content
 };
+
+config = _.defaults(config, DEFAULTS);
 
 var ouija = new Ouija(config);
 

--- a/app/ouija.jsx
+++ b/app/ouija.jsx
@@ -33,8 +33,9 @@ module.exports = Ouija;
  */
 function Ouija(config) {
   _.extend(this, {
-    _url: config.connect_url,
+    _url: config.connectUrl,
     _identifier: config.identifier,
+    _articleContent: config.articleContent,
     _el: {}
   });
 }
@@ -51,18 +52,20 @@ Ouija.prototype.initialize = function() {
   this._labelSections();
   this._renderSections();
 
-  $('article.post').addClass('post-ouija');
+  $('article').addClass('post-ouija');
 };
 
 Ouija.prototype._connect = function() {
+  var self = this;
+
   return goinstant.connect(this._url, {
-    room: ['lobby', 'post_' + window.ouija_identifier]
+    room: ['lobby', 'post_' + self._identifier]
   });
 };
 
 Ouija.prototype._parseContent = function() {
-  var selector = window.ouija_article_content || '.post-content';
-  this._el.content = $(selector);
+  this._el.content = $(this._articleContent);
+
   this._el.sections = _.reject(this._el.content.find('p, ol'), function(el) {
     return _($(el).text()).isEmpty();
   });


### PR DESCRIPTION
- Makes the article selector less precise when adding the `ouija-post` class so it will work with more themes. There should only ever be 1 article tag on a post anyway.
