### PR TITLE
fix(click controls): don't collapse on all clicks

### DIFF
--- a/app/components/comment-controls.jsx
+++ b/app/components/comment-controls.jsx
@@ -13,7 +13,7 @@ var React = require('react');
 
 var AddControl = React.createClass({
   render: function() {
-    return (<a href="#" className="add" onClick={ this.props.onClick }></a>);
+    return (<a href="#" className="add"></a>);
   }
 });
 
@@ -30,7 +30,7 @@ var LoadControl = React.createClass({
 var CountControl = React.createClass({
   render: function() {
     return (
-      <a href="#" className="count"  onClick={ this.props.onClick }>
+      <a href="#" className="count">
         <span>{ this.props.count }</span>
       </a>
     );
@@ -44,16 +44,13 @@ CommentControls.render = function() {
 
   if (!this.props.isLoading) {
     activeControl = (
-      <AddControl
-        onClick={ this.props.onAddClick }
-      />
+      <AddControl />
     );
   }
 
   if (this.props.commentCount) {
     activeControl = (
       <CountControl
-        onClick={ this.props.onAddClick }
         count={ this.props.commentCount }
       />
     );

--- a/app/components/comment-form.jsx
+++ b/app/components/comment-form.jsx
@@ -84,7 +84,7 @@ CommentForm.render = function() {
       <div className="ouija-content">
         <textarea ref="content" placeholder="Leave a comment..."></textarea>
         <footer>
-          <button className="text" onClick={ this.handleCancel }>Cancel</button>
+          <button className="text ouija-cancel" onClick={ this.handleCancel }>Cancel</button>
           <button type="submit">Comment</button>
         </footer>
       </div>

--- a/app/components/conversation.jsx
+++ b/app/components/conversation.jsx
@@ -9,7 +9,7 @@
  * Conversation React Component
  **/
 
-var React = require('react/addons');
+var React = require('react');
 var _ = require('lodash');
 
 var CommentList = require('./comment-list');
@@ -27,55 +27,10 @@ Conversation.getInitialState = function() {
   };
 };
 
-Conversation.monitorComments = function() {
-  var self = this;
-
-  var $post = $('.post-ouija');
-  var $currentConversation = $(self.getDOMNode());
-  var $document = $(document);
-  var disregardEvent = false;
-
-  this.voidClick = function() {
-    self.disregardEvent = true;
-  }
-
-  $document.on('click', this.hideComments);
-  $currentConversation.on('click', this.voidClick);
-
-  $post.addClass('ouija-active');
-};
-
-Conversation.hideComments = function() {
-  var self = this;
-
-  if (self.disregardEvent) {
-    self.disregardEvent = false;
-    return;
-  };
-
-  var $post = $('.post-ouija');
-  var $currentConversation = $(self.getDOMNode());
-  var $document = $(document);
-
-  $document.off('click', this.hideComments);
-  $currentConversation.off('click', this.voidClick);
-  $post.removeClass('ouija-active');
-  self.setState({ isActive: false });
-};
-
-Conversation.handleAddClick = function(e) {
-  this.monitorComments();
-  this.setState({ isActive: !this.state.isActive });
-  e.preventDefault();
-};
-
 Conversation.handleCommentSubmit = function(comment) {
   var sectionName = this.props.section;
 
   this.props.comments.add(sectionName, comment);
-};
-Conversation.handleCommentClose = function() {
-  this.hideComments();
 };
 
 Conversation.componentWillMount = function() {
@@ -85,7 +40,7 @@ Conversation.componentWillMount = function() {
   comments.getComments(this.props.section).then(function(comments) {
     self.setState({ comments: comments, loading: false, count: _.keys(comments).length });
   }).fail(function(err) {
-    console.log('wuh oh', err)
+    console.log('wuh oh', err);
   });
 
   comments.on('newComment', function(sectionName) {
@@ -98,18 +53,11 @@ Conversation.componentWillMount = function() {
 };
 
 Conversation.render = function() {
-  var cx = React.addons.classSet;
-  var classes = cx({
-    'ouija': true,
-    'ouija-active': this.state.isActive
-  });
-
   return (
-    <div className={ classes }>
+    <div className="ouija">
       <CommentControls
         isLoading={ this.state.loading }
         commentCount={ this.state.count }
-        onAddClick={ this.handleAddClick }
       />
 
       <div className="ouija-comments">


### PR DESCRIPTION
Closes #28 

Moves and improves the control click logic out of the conversation component so we can manage the global state of all conversations.
- If the currently active conversation's control is clicked the conversation closes.
- If conversation A is open and the user clicks conversation B's control, A closes and B opens.
- If the active conversation itself is clicked, it doesn't close
- If anywhere else on the document is clicked, the conversation will close.
