### PR TITLE
Tweak thread animation

### DIFF
--- a/app/styles/ouija.scss
+++ b/app/styles/ouija.scss
@@ -381,6 +381,12 @@ $loader-color: #222;
   //Active post
   &.ouija-active {
     @include resize-content($offset-push, $offset-width);
+
+    //Stop animation when moving to another comment thread
+    .ouija .ouija-comments {
+      // margin-left: 0;
+    }
+
   }
 
   //Trigger Ouija to show on hover of these elements


### PR DESCRIPTION
Comments don't animate in if there is already a drawer open.

![ghost-new](https://cloud.githubusercontent.com/assets/1572205/2905691/9cb6042c-d607-11e3-8548-29310d34a12d.gif)

---

Before:
![ghost-old](https://cloud.githubusercontent.com/assets/1572205/2905696/ae2226a0-d607-11e3-8baf-96c8816eaaeb.gif)
