### PR TITLE
Replace quotemarks with single quotes.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,61 +1,53 @@
 {
-    // Settings
-    "passfail"      : false,  // Stop on first error.
-    "maxerr"        : 100,    // Maximum error before stopping.
+    "passfail"      : false,
+    "maxerr"        : 100,
  
- 
-    // Predefined globals whom JSHint will ignore.
-    "browser"       : true,   // Standard browser globals e.g. `window`, `document`.
- 
+    "browser"       : true,
     "node"          : false,
-    "jquery"        : true, 
+    "jquery"        : true,
     "predef"        : [ "goinstant" ],
  
+    "debug"         : false,  
+    "devel"         : true,   
  
-    // Development.
-    "debug"         : false,  // Allow debugger statements e.g. browser breakpoints.
-    "devel"         : true,   // Allow developments statements e.g. `console.log();`.
+    "strict"        : false,  
+    "globalstrict"  : false,  
+
+    "quotmark"      : "single",
+
  
- 
-    // ECMAScript 5.
-    "strict"        : false,  // Require `use strict` pragma  in every file.
-    "globalstrict"  : false,  // Allow global "use strict" (also enables 'strict').
- 
- 
-    // The Good Parts.
-    "asi"           : false,  // Tolerate Automatic Semicolon Insertion (no semicolons).
-    "laxbreak"      : false,  // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
-    "bitwise"       : true,   // Prohibit bitwise operators (&, |, ^, etc.).
-    "boss"          : false,  // Tolerate assignments inside if, for & while. Usually conditions & loops are for comparison, not assignments.
-    "curly"         : true,   // Require {} for every new block or scope.
-    "eqeqeq"        : true,   // Require triple equals i.e. `===`.
-    "eqnull"        : false,  // Tolerate use of `== null`.
-    "evil"          : false,  // Tolerate use of `eval`.
-    "expr"          : false,  // Tolerate `ExpressionStatement` as Programs.
-    "forin"         : false,  // Tolerate `for in` loops without `hasOwnPrototype`.
-    "immed"         : true,   // Require immediate invocations to be wrapped in parens e.g. `( function(){}() );`
-    "latedef"       : true,   // Prohipit variable use before definition.
-    "loopfunc"      : false,  // Allow functions to be defined within loops.
-    "noarg"         : true,   // Prohibit use of `arguments.caller` and `arguments.callee`.
-    "regexp"        : true,   // Prohibit `.` and `[^...]` in regular expressions.
-    "regexdash"     : false,  // Tolerate unescaped last dash i.e. `[-...]`.
-    "scripturl"     : true,   // Tolerate script-targeted URLs.
-    "shadow"        : false,  // Allows re-define variables later in code e.g. `var x=1; x=2;`.
-    "supernew"      : false,  // Tolerate `new function () { ... };` and `new Object;`.
-    "undef"         : true,   // Require all non-global variables be declared before they are used.
+    "asi"           : false,
+    "laxbreak"      : false,
+    "bitwise"       : true,
+    "boss"          : false,
+    "curly"         : true,
+    "eqeqeq"        : true,
+    "eqnull"        : false,  
+    "evil"          : false,
+    "expr"          : false,
+    "forin"         : false,
+    "immed"         : true,
+    "latedef"       : true,
+    "loopfunc"      : false,
+    "noarg"         : true,
+    "regexp"        : true,
+    "regexdash"     : false,
+    "scripturl"     : true,
+    "shadow"        : false,
+    "supernew"      : false,
+    "undef"         : true,
  
     "nomen"         : false,
     "unused"        : true,
 
-    // Personal styling preferences.
-    "newcap"        : false,  // Require capitalization of all constructor functions e.g. `new F()`.
-    "noempty"       : true,   // Prohibit use of empty blocks.
-    "nonew"         : true,   // Prohibit use of constructors for side-effects.
-    "nomen"         : true,   // Prohibit use of initial or trailing underbars in names.
-    "onevar"        : true,   // Allow only one `var` statement per function.
-    "plusplus"      : true,   // Prohibit use of `++` & `--`.
-    "sub"           : true,   // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
-    "trailing"      : true,   // Prohibit trailing whitespaces.
-    "white"         : true,   // Check against strict whitespace and indentation rules.
-    "indent"        : 4       // Specify indentation spacing
+    "newcap"        : false,
+    "noempty"       : true,
+    "nonew"         : true,
+    "nomen"         : true,
+    "onevar"        : true,
+    "plusplus"      : true,
+    "sub"           : true,
+    "trailing"      : true,
+    "white"         : true,
+    "indent"        : 4
 }

--- a/app/components/comment-controls.js
+++ b/app/components/comment-controls.js
@@ -15,15 +15,15 @@ var React = require('react'),
 
 AddControl = React.createClass({displayName: 'AddControl',
     render: function () {
-        return React.DOM.a({ href: "#", className: "add"});
+        return React.DOM.a({ href: '#', className: 'add'});
     }
 });
 
 LoadControl = React.createClass({
     displayName: 'LoadControl',
     render: function () {
-        return React.DOM.a({ href: "#", className: "loader"}, 
-            React.DOM.span({ className: "ouija-loader"})
+        return React.DOM.a({ href: '#', className: 'loader'}, 
+            React.DOM.span({ className: 'ouija-loader'})
         );
     }
 });
@@ -31,7 +31,7 @@ LoadControl = React.createClass({
 CountControl = React.createClass({
     displayName: 'CountControl',
     render: function () {
-        return React.DOM.a({ href: "#", className: "count"}, 
+        return React.DOM.a({ href: '#', className: 'count'}, 
             React.DOM.span(null, this.props.count )
         );
     }
@@ -50,7 +50,7 @@ CommentControls.render = function () {
         activeControl = CountControl({ count: this.props.commentCount });
     }
 
-    return React.DOM.div({ className: "ouija-controls"},  activeControl);
+    return React.DOM.div({ className: 'ouija-controls'},  activeControl);
 };
 
 module.exports = React.createClass(CommentControls);

--- a/app/components/comment-form.js
+++ b/app/components/comment-form.js
@@ -68,22 +68,22 @@ CommentForm.render = function () {
         return this.state.loginComponent;
     }
     
-    return React.DOM.form({ className: "ouija-comment ouija-new", onSubmit: this.handleSubmit }, 
-        React.DOM.span({ className: "ouija-avatar"}, 
-            React.DOM.img({ src: this.state.user.avatarUrl, alt: "avatar"})
+    return React.DOM.form({ className: 'ouija-comment ouija-new', onSubmit: this.handleSubmit }, 
+        React.DOM.span({ className: 'ouija-avatar'}, 
+            React.DOM.img({ src: this.state.user.avatarUrl, alt: 'avatar'})
         ),
-        React.DOM.div({ className: "ouija-author"}, 
+        React.DOM.div({ className: 'ouija-author'}, 
             React.DOM.a({
-                href: "https://twitter.com/" + this.state.user.username, 
-                alt: "{ this.state.user.displayName }"
+                href: 'https://twitter.com/' + this.state.user.username, 
+                alt: '{ this.state.user.displayName }'
             }, this.state.user.displayName),
-            React.DOM.a({ className: "ouija-button text", href: this.state.logoutUrl }, "Logout")
+            React.DOM.a({ className: 'ouija-button text', href: this.state.logoutUrl }, 'Logout')
         ),
-        React.DOM.div({ className: "ouija-content"}, 
-            React.DOM.textarea({ ref: "content", placeholder: "Leave a comment..."}),
+        React.DOM.div({ className: 'ouija-content'}, 
+            React.DOM.textarea({ ref: 'content', placeholder: 'Leave a comment...'}),
             React.DOM.footer(null, 
-                React.DOM.button({ className: "text ouija-cancel", onClick: this.handleCancel }, "Cancel"),
-                React.DOM.button({ type: "submit"}, "Comment")
+                React.DOM.button({ className: 'text ouija-cancel', onClick: this.handleCancel }, 'Cancel'),
+                React.DOM.button({ type: 'submit'}, 'Comment')
             )
         )
     );

--- a/app/components/comment.js
+++ b/app/components/comment.js
@@ -11,16 +11,16 @@ var React = require('react'),
     Comment = {};
 
 Comment.render = function () {
-    return React.DOM.div({ className: "ouija-comment"}, 
-        React.DOM.span({ className: "ouija-avatar"}, 
-            React.DOM.img({ src: this.props.author.avatarUrl, alt: "avatar"})
+    return React.DOM.div({ className: 'ouija-comment'}, 
+        React.DOM.span({ className: 'ouija-avatar'}, 
+            React.DOM.img({ src: this.props.author.avatarUrl, alt: 'avatar'})
         ),
-        React.DOM.div({ className:"ouija-author"}, 
-            React.DOM.a({ href: "https://twitter.com/" + this.props.author.username, alt: "Timestamp"}, 
+        React.DOM.div({ className:'ouija-author'}, 
+            React.DOM.a({ href: 'https://twitter.com/' + this.props.author.username, alt: 'Timestamp'}, 
                  this.props.author.displayName 
             )
         ),
-        React.DOM.div({ className: "ouija-content"}, 
+        React.DOM.div({ className: 'ouija-content'}, 
             React.DOM.p(null, this.props.children )
         )
     );

--- a/app/components/conversation.js
+++ b/app/components/conversation.js
@@ -57,13 +57,13 @@ Conversation.render = function () {
             'ouija-has-comments': this.state.count
         });
 
-    return React.DOM.div({ className: "ouija " + classes }, 
+    return React.DOM.div({ className: 'ouija ' + classes }, 
         CommentControls({
             isLoading: this.state.loading, 
             commentCount: this.state.count
         }),
 
-        React.DOM.div({ className:"ouija-comments"}, 
+        React.DOM.div({ className:'ouija-comments'}, 
             CommentList({ data: this.state.comments }),
             CommentForm({
                 onCommentSubmit: this.handleCommentSubmit, 

--- a/app/components/login.js
+++ b/app/components/login.js
@@ -11,11 +11,11 @@ var React = require('react'),
     Login = {};
 
 Login.render = function () {
-    return React.DOM.form({ className: "ouija-comment ouija-login"}, 
-        React.DOM.h5(null, "Sign in to comment"),
-        React.DOM.a({ href: this.props.loginUrl,  className: "ouija-button"}, 
-            React.DOM.span({ className: "icon-twitter"}),
-            "Sign in with Twitter"
+    return React.DOM.form({ className: 'ouija-comment ouija-login'}, 
+        React.DOM.h5(null, 'Sign in to comment'),
+        React.DOM.a({ href: this.props.loginUrl,  className: 'ouija-button'}, 
+            React.DOM.span({ className: 'icon-twitter'}),
+            'Sign in with Twitter'
         )
     );
 };

--- a/app/index.js
+++ b/app/index.js
@@ -11,7 +11,7 @@ var _     = require('lodash'),
     Ouija = require('./ouija'),
     DEFAULTS = {
         articleContent: '.post-content',
-        sectionElements: "p, ol, :has(img)"
+        sectionElements: 'p, ol, :has(img)'
     },
     config,
     ouija;


### PR DESCRIPTION
Fix jshintrc.

@colinmacdonald reminded me that Ghost only uses single quotes in the code. While this isn’t currently checked on the Ghost side (because there are still some double quotes lingering around) I moved to all single-quotes with this PR.

The .jshintrc was still containing comments (which is sadly not support by JSON). They are removed now.
